### PR TITLE
Use queue a to avoid concurrent refresh tokens

### DIFF
--- a/src/api/setupInterceptors.js
+++ b/src/api/setupInterceptors.js
@@ -1,80 +1,73 @@
+import axios from 'axios';
 import apiInstance from './api';
 import { refreshToken } from './services/auth';
 import setAlert from '../utils/setAlert';
 
 const setup = (store) => {
 
+    let isRefreshing = false;
+    let refreshSubscribers = [];
+
+    const subscribeTokenRefresh = (cb) => {
+        refreshSubscribers.push(cb);
+    };
+
+    const onRefreshed = (token) => {
+        refreshSubscribers.map(cb => cb(token));
+    };
+
     apiInstance.interceptors.request.use((request) => {
-   
         const state = store.getState();
         const token = state.account.token;
 
-        if(request.url.includes("refresh")) {
+        if (request.url.includes("refresh")) {
             delete apiInstance.defaults.headers.common["Authorization"];
-        } else if (token){
+        } else if (token) {
             // request.headers.Authorization = `Bearer ${token}`;
             apiInstance.defaults.headers.common['Authorization'] = `Bearer ${token}`;
         }
 
         return request;
-
     });
 
-    apiInstance.interceptors.response.use((response) => {
-     
+    apiInstance.interceptors.response.use(response => {
         return response;
-        },(error) => {
-            
-            // Generic error: Connection to server failed
-            if (!error.response) {
-    
-                setAlert("Falló la conexión al servidor","error");
-                console.log("Falló la conexión al servidor");
-    
-            } 
-            /*
-            else {
-    
-                console.log(JSON.stringify(error.config.url));
-                console.log(JSON.stringify(error.config.method));
-                console.log(JSON.stringify(error.config.data));
-                console.log(JSON.stringify(error.response.status));
-                console.log(JSON.stringify(error.response.data.msg));
-    
-            }      
-            */
-
-            const originalConfig = error.config;
-
-            if (error.response.data.code === 'token_not_valid' && !originalConfig._retry && !((JSON.stringify(error.config.url)).includes("refresh"))){
-              
-                originalConfig._retry = true;
-
-                return refreshToken()
-                    .then((res) => { 
- 
-                        const state = store.getState();
-                        const token = state.account.token;
-                        
-                        originalConfig.headers.Authorization = `Bearer ${token}`;
-
-                        return apiInstance(originalConfig);
-
-                    }).catch((err) => { 
-                        console.log("catch: el refresh dio error");
-                        return Promise.reject(err);
-                    });
-            } else {
-                
-                // Cuando falla el refresh, el error entra por acá, luego por auth.js y luego por el catch del refresh (del setupinterceptor.js)
-                console.log("Error en el setupinterceptor");
-                return Promise.reject(error);
-            }
-    
-
+    }, error => {
+        if (!error.response) {
+            setAlert("Falló la conexión al servidor", "error");
+            console.log("Falló la conexión al servidor");
         }
-    );
 
+        const originalRequest = error.config;
+
+        if (error.response.data.code === 'token_not_valid' && !originalRequest._retry && !((JSON.stringify(originalRequest.url)).includes("refresh"))) {
+            originalRequest._retry = true;
+
+            if (!isRefreshing) {
+                isRefreshing = true;
+                refreshToken()
+                    .then(response => {
+                        isRefreshing = false;
+                        let newToken = response.data.access;
+                        onRefreshed(newToken);
+                        refreshSubscribers = [];
+                    });
+            }
+
+            const retryOrigReq = new Promise((resolve, reject) => {
+                subscribeTokenRefresh(token => {
+                    // replace the expired token and retry
+                    originalRequest.headers['Authorization'] = 'Bearer ' + token;
+                    return resolve(axios(originalRequest));
+                });
+            });
+
+            return retryOrigReq;
+        } else {
+            console.log("Error en el setupinterceptor");
+            return Promise.reject(error);
+        }
+    });
 };
 
 


### PR DESCRIPTION
Original problem:
Access metrics when access must be renew, many ctoken/refresh executed.

![image](https://github.com/CERTUNLP/ngen-frontend/assets/668847/cb752271-d5ce-44af-a816-a04ab5720467)


Solution:
![image](https://github.com/CERTUNLP/ngen-frontend/assets/668847/6b8676b3-321e-4193-b25e-aa02ba980a31)
